### PR TITLE
:wrench: Add missing settings for TWO_FACTOR_WEBAUTHN

### DIFF
--- a/open_api_framework/conf/base.py
+++ b/open_api_framework/conf/base.py
@@ -632,6 +632,11 @@ else:
 
 # we run the admin site monkeypatch instead.
 TWO_FACTOR_PATCH_ADMIN = False
+# Relying Party name for WebAuthn (hardware tokens)
+TWO_FACTOR_WEBAUTHN_RP_NAME = f"{PROJECT_DIRNAME} - admin"
+# use platform for fingerprint readers etc., or remove the setting to allow any.
+# cross-platform would limit the options to devices like phones/yubikeys
+TWO_FACTOR_WEBAUTHN_AUTHENTICATOR_ATTACHMENT = "cross-platform"
 # add entries from AUTHENTICATION_BACKENDS that already enforce their own two-factor
 # auth, avoiding having some set up MFA again in the project.
 MAYKIN_2FA_ALLOW_MFA_BYPASS_BACKENDS = [


### PR DESCRIPTION
I was a bit too quick in making a new release :sweat_smile: 