### PR TITLE
:bug: Add missing help_text for cookie samesite envvars

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+0.7.1 (2024-08-16)
+------------------
+
+**Bugfixes**
+
+* Add missing help_text for SESSION_COOKIE_SAMESITE and CSRF_COOKIE_SAMESITE envvars
+
 0.7.0 (2024-08-15)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Open API Framework
 ==================
 
-:Version: 0.7.0
+:Version: 0.7.1
 :Source: https://github.com/maykinmedia/open-api-framework
 :Keywords: metapackage, dependencies
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ copyright = "2024, Maykin Media"
 author = "Maykin Media"
 
 # The full version, including alpha/beta/rc tags
-release = "0.7.0"
+release = "0.7.1"
 
 
 # -- General configuration ---------------------------------------------------

--- a/open_api_framework/conf/base.py
+++ b/open_api_framework/conf/base.py
@@ -539,10 +539,25 @@ LOGOUT_REDIRECT_URL = reverse_lazy("admin:index")
 #
 SESSION_COOKIE_SECURE = IS_HTTPS
 SESSION_COOKIE_HTTPONLY = True
-SESSION_COOKIE_SAMESITE = config("SESSION_COOKIE_SAMESITE", "Strict")
+SESSION_COOKIE_SAMESITE = config(
+    "SESSION_COOKIE_SAMESITE",
+    "Strict",
+    help_text=(
+        "The value of the SameSite flag on the session cookie. This flag prevents the "
+        "cookie from being sent in cross-site requests thus preventing CSRF attacks and "
+        "making some methods of stealing session cookie impossible."
+    ),
+)
 
 CSRF_COOKIE_SECURE = IS_HTTPS
-CSRF_COOKIE_SAMESITE = config("CSRF_COOKIE_SAMESITE", "Strict")
+CSRF_COOKIE_SAMESITE = config(
+    "CSRF_COOKIE_SAMESITE",
+    "Strict",
+    help_text=(
+        "The value of the SameSite flag on the CSRF cookie. This flag prevents the cookie "
+        "from being sent in cross-site requests."
+    ),
+)
 
 X_FRAME_OPTIONS = "DENY"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "open_api_framework"
-version = "0.7.0"
+version = "0.7.1"
 description = "A metapackage for registration components, that bundles the dependencies shared between these components and provides generic settings"
 authors = [
     {name = "Maykin Media", email = "support@maykinmedia.nl"}
@@ -100,7 +100,7 @@ testpaths = ["tests"]
 DJANGO_SETTINGS_MODULE = "testapp.settings"
 
 [tool.bumpversion]
-current_version = "0.7.0"
+current_version = "0.7.1"
 files = [
     {filename = "pyproject.toml"},
     {filename = "README.rst"},


### PR DESCRIPTION
Forgot to add these before releasing :grimacing: 