### PR TITLE
:wrench: Move docker required envvars to Required group

### DIFF
--- a/open_api_framework/conf/base.py
+++ b/open_api_framework/conf/base.py
@@ -149,12 +149,17 @@ DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 CACHE_DEFAULT = config(
     "CACHE_DEFAULT",
     "localhost:6379/0",
-    help_text="redis cache address for the default cache",
+    help_text="redis cache address for the default cache (this **MUST** be set when using Docker)",
+    group="Required",
 )
 CACHE_AXES = config(
     "CACHE_AXES",
     "localhost:6379/0",
-    help_text="redis cache address for the brute force login protection cache",
+    help_text=(
+        "redis cache address for the brute force login protection cache "
+        "(this **MUST** be set when using Docker)"
+    ),
+    group="Required",
 )
 
 CACHES = {
@@ -307,7 +312,8 @@ FILE_UPLOAD_PERMISSIONS = 0o644
 EMAIL_HOST = config(
     "EMAIL_HOST",
     default="localhost",
-    help_text="hostname for the outgoing e-mail server",
+    help_text="hostname for the outgoing e-mail server (this **MUST** be set when using Docker)",
+    group="Required",
 )
 EMAIL_PORT = config(
     "EMAIL_PORT",
@@ -612,7 +618,7 @@ if subpath:
     SUBPATH = subpath
 
 if "GIT_SHA" in os.environ:
-    GIT_SHA = config("GIT_SHA", "")
+    GIT_SHA = config("GIT_SHA", "", add_to_docs=False)
 # in docker (build) context, there is no .git directory
 elif (Path(BASE_DIR) / ".git").exists():
     try:

--- a/open_api_framework/templates/open_api_framework/env_config.rst
+++ b/open_api_framework/templates/open_api_framework/env_config.rst
@@ -13,7 +13,7 @@ Available environment variables
 {{group_name}}
 {{group_name|repeat_char:"-"}}
 
-{% for var in vars %}* ``{{var.name}}``: {% if var.help_text %}{{var.help_text|safe|ensure_endswith:"."}}{% endif %}{% if var.auto_display_default and not var.default|is_undefined %} Defaults to: ``{{var.default|to_str}}``.{% endif %}
+{% for var in vars %}* ``{{var.name}}``: {% if var.help_text %}{{var.help_text|safe|ensure_endswith:"."}}{% endif %}{% if var.auto_display_default and not var.default|is_undefined %} Defaults to: ``{{var.default|to_str|safe}}``.{% endif %}
 {% endfor %}
 {% endfor %}
 


### PR DESCRIPTION
In the OZ/ON docs these were marked as `Required` for docker https://open-zaak.readthedocs.io/en/stable/installation/config/env_config.html