### PR TITLE
Add missing `authorizations` app for `commonground-api-common`

### DIFF
--- a/open_api_framework/conf/base.py
+++ b/open_api_framework/conf/base.py
@@ -211,6 +211,7 @@ INSTALLED_APPS = [
     "csp",
     "corsheaders",
     "vng_api_common",
+    "vng_api_common.authorizations",
     "notifications_api_common",
     "drf_spectacular",
     "rest_framework",


### PR DESCRIPTION
Fixes `makemigrations` creating a new migration for several authorization models.

**Changes**
The migrations that are currently generated when running `makemigrations` in `open-klant` generates a migration with models for the `authorizations` app because the migrations in the existing app are not recognized (as the app is not in the `INSTALLED_APPS`)

See https://github.com/maykinmedia/commonground-api-common/blob/1.12.1/docs/quickstart.rst?plain=1#L43.
Also see the `check_migrations` [CI job](https://github.com/maykinmedia/open-klant/actions/runs/10881884346/job/30191758226?pr=238) that encountered this issue.
