### PR TITLE
[#1784] fix runtime configuration for django-log-outgoing-requests

### DIFF
--- a/open_api_framework/conf/base.py
+++ b/open_api_framework/conf/base.py
@@ -1041,3 +1041,17 @@ CSP_FRAME_SRC = ["'self'"]
 # CSP_SANDBOX # too much
 
 CSP_UPGRADE_INSECURE_REQUESTS = False  # TODO enable on production?
+
+
+#
+# Django Solo
+#
+SOLO_CACHE = config(
+    "SOLO_CACHE",
+    default="default",
+    help_text=(
+        "The cache which will be used by Django Solo. Can be set to an empty "
+        "string to disable caching for Django Solo."
+    ),
+    cast=lambda value: value if value else None
+)

--- a/open_api_framework/conf/base.py
+++ b/open_api_framework/conf/base.py
@@ -501,7 +501,7 @@ LOGGING = {
             "handlers": (
                 ["log_outgoing_requests", "save_outgoing_requests"]
                 if LOG_REQUESTS
-                else []
+                else ["save_outgoing_requests"]
             ),
             "level": "DEBUG",
             "propagate": True,

--- a/open_api_framework/conf/base.py
+++ b/open_api_framework/conf/base.py
@@ -1053,5 +1053,5 @@ SOLO_CACHE = config(
         "The cache which will be used by Django Solo. Can be set to an empty "
         "string to disable caching for Django Solo."
     ),
-    cast=lambda value: value if value else None
+    cast=lambda value: value if value else None,
 )

--- a/open_api_framework/conf/base.py
+++ b/open_api_framework/conf/base.py
@@ -1046,12 +1046,4 @@ CSP_UPGRADE_INSECURE_REQUESTS = False  # TODO enable on production?
 #
 # Django Solo
 #
-SOLO_CACHE = config(
-    "SOLO_CACHE",
-    default="default",
-    help_text=(
-        "The cache which will be used by Django Solo. Can be set to an empty "
-        "string to disable caching for Django Solo."
-    ),
-    cast=lambda value: value if value else None,
-)
+SOLO_CACHE = "default"


### PR DESCRIPTION
Partially fixes https://github.com/open-zaak/open-zaak/issues/1784

Previously, setting the `LOG_REQUESTS` setting to `False` caused the runtime configuration of django-log-outgoing-requests to break. This was caused by [no handlers being configured for its logger](https://github.com/maykinmedia/open-api-framework/blob/0.8.0/open_api_framework/conf/base.py#L504).

As the runtime configuration at the moment only allows configuring saving to the database (or not):

![image](https://github.com/user-attachments/assets/88160125-6b36-4022-80a8-c0ed610fac7d)

 the `save_outgoing_requests` handler should always be included in the corresponding `LOGGING` setting.

**Changes**

Fixes the option to configure django-log-outgoing through the django admin.