### PR TITLE
:wrench: [#88] Remove SENTRY_BEFORE_SEND envvar

### DIFF
--- a/open_api_framework/conf/base.py
+++ b/open_api_framework/conf/base.py
@@ -818,24 +818,12 @@ SENTRY_DSN = config(
     auto_display_default=False,
 )
 
-SENTRY_BEFORE_SEND = config(
-    "SENTRY_BEFORE_SEND",
-    None,
-    help_text=(
-        "Callback, which allows projects to define their own before_send filters"
-    ),
-    auto_display_default=False,
-)
-
 if SENTRY_DSN:
     SENTRY_CONFIG = {
         "dsn": SENTRY_DSN,
         "release": RELEASE or "RELEASE not set",
         "environment": ENVIRONMENT,
     }
-
-    if SENTRY_BEFORE_SEND:
-        SENTRY_CONFIG["before_send"] = SENTRY_BEFORE_SEND
 
     sentry_sdk.init(
         **SENTRY_CONFIG,

--- a/tests/test_generate_envvar_docs.py
+++ b/tests/test_generate_envvar_docs.py
@@ -98,7 +98,6 @@ Optional
 * ``CSRF_TRUSTED_ORIGINS``: A list of trusted origins for unsafe requests (e.g. POST). Defaults to: ``[]``.
 * ``NOTIFICATIONS_DISABLED``: indicates whether or not notifications should be sent to the Notificaties API for operations on the API endpoints. Defaults to ``True`` for the ``dev`` environment, otherwise defaults to ``False``.
 * ``SENTRY_DSN``: URL of the sentry project to send error reports to. Default empty, i.e. -> no monitoring set up. Highly recommended to configure this.
-* ``SENTRY_BEFORE_SEND``: Callback, which allows projects to define their own before_send filters.
 * ``DISABLE_2FA``: Whether or not two factor authentication should be disabled. Defaults to: ``False``.
 * ``LOG_OUTGOING_REQUESTS_EMIT_BODY``: Whether or not outgoing request bodies should be logged. Defaults to: ``True``.
 * ``LOG_OUTGOING_REQUESTS_DB_SAVE``: Whether or not outgoing request logs should be saved to the database. Defaults to: ``False``.


### PR DESCRIPTION
instead of setting this via an envvar, projects that want to define before_send hooks should initialize sentry themselves and specify before_send

Fixes #88

Related PR https://github.com/open-zaak/open-zaak/pull/1919/files#diff-f0610b8a481831a7af79c8f5c13f9815193de5f27da8dfc0dce23c1959358cefR17

**Changes**

* Remove SENTRY_BEFORE_SEND envvar

