### PR TITLE
:white_check_mark: Add SITE_DOMAIN env var

### DIFF
--- a/open_api_framework/conf/base.py
+++ b/open_api_framework/conf/base.py
@@ -35,6 +35,12 @@ SITE_ID = config(
     help_text="The database ID of the site object. You usually won't have to touch this.",
 )
 
+SITE_DOMAIN = config(
+    "SITE_DOMAIN",
+    default="example.com",
+    help_text=("Defines the primary domain where the application is hosted."),
+)
+
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = config(
     "SECRET_KEY",

--- a/tests/test_generate_envvar_docs.py
+++ b/tests/test_generate_envvar_docs.py
@@ -75,6 +75,7 @@ Optional
 --------
 
 * ``SITE_ID``: The database ID of the site object. You usually won't have to touch this. Defaults to: ``1``.
+* ``SITE_DOMAIN``: Defines the primary domain where the application is hosted. Defaults to: ``example.com``.
 * ``DEBUG``: Only set this to ``True`` on a local development environment. Various other security settings are derived from this setting!. Defaults to: ``False``.
 * ``USE_X_FORWARDED_HOST``: whether to grab the domain/host from the X-Forwarded-Host header or not. This header is typically set by reverse proxies (such as nginx, traefik, Apache...). Note: this is a header that can be spoofed and you need to ensure you control it before enabling this. Defaults to: ``False``.
 * ``IS_HTTPS``: Used to construct absolute URLs and controls a variety of security settings. Defaults to the inverse of ``DEBUG``.


### PR DESCRIPTION
The env variable `SITE_DOMAIN` was added to partially solve https://github.com/maykinmedia/open-api-framework/issues/59 where `django.contrib.sites` is removed from other projects.