### PR TITLE
:fire: [#59] Remove django.contrib.sites from INSTALLED_APPS

### DIFF
--- a/open_api_framework/conf/base.py
+++ b/open_api_framework/conf/base.py
@@ -29,17 +29,6 @@ BASE_DIR = Path(DJANGO_PROJECT_DIR).resolve().parents[1]
 #
 # Core Django settings
 #
-SITE_ID = config(
-    "SITE_ID",
-    default=1,
-    help_text="The database ID of the site object. You usually won't have to touch this.",
-)
-
-SITE_DOMAIN = config(
-    "SITE_DOMAIN",
-    default="example.com",
-    help_text=("Defines the primary domain where the application is hosted."),
-)
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = config(
@@ -199,8 +188,6 @@ INSTALLED_APPS = [
     "django.contrib.contenttypes",
     "django.contrib.auth",
     "django.contrib.sessions",
-    # Note: If enabled, at least one Site object is required
-    "django.contrib.sites",
     "django.contrib.messages",
     "django.contrib.staticfiles",
     # Optional applications.
@@ -809,6 +796,11 @@ NOTIFICATIONS_DISABLED = config(
         "Defaults to ``True`` for the ``dev`` environment, otherwise defaults to ``False``"
     ),
     auto_display_default=False,
+)
+SITE_DOMAIN = config(
+    "SITE_DOMAIN",
+    default="example.com",
+    help_text=("Defines the primary domain where the application is hosted."),
 )
 
 #

--- a/tests/test_generate_envvar_docs.py
+++ b/tests/test_generate_envvar_docs.py
@@ -74,8 +74,6 @@ Content Security Policy
 Optional
 --------
 
-* ``SITE_ID``: The database ID of the site object. You usually won't have to touch this. Defaults to: ``1``.
-* ``SITE_DOMAIN``: Defines the primary domain where the application is hosted. Defaults to: ``example.com``.
 * ``DEBUG``: Only set this to ``True`` on a local development environment. Various other security settings are derived from this setting!. Defaults to: ``False``.
 * ``USE_X_FORWARDED_HOST``: whether to grab the domain/host from the X-Forwarded-Host header or not. This header is typically set by reverse proxies (such as nginx, traefik, Apache...). Note: this is a header that can be spoofed and you need to ensure you control it before enabling this. Defaults to: ``False``.
 * ``IS_HTTPS``: Used to construct absolute URLs and controls a variety of security settings. Defaults to the inverse of ``DEBUG``.
@@ -98,6 +96,7 @@ Optional
 * ``NUM_PROXIES``: the number of reverse proxies in front of the application, as an integer. This is used to determine the actual client IP adres. On Kubernetes with an ingress you typically want to set this to 2. Defaults to: ``1``.
 * ``CSRF_TRUSTED_ORIGINS``: A list of trusted origins for unsafe requests (e.g. POST). Defaults to: ``[]``.
 * ``NOTIFICATIONS_DISABLED``: indicates whether or not notifications should be sent to the Notificaties API for operations on the API endpoints. Defaults to ``True`` for the ``dev`` environment, otherwise defaults to ``False``.
+* ``SITE_DOMAIN``: Defines the primary domain where the application is hosted. Defaults to: ``example.com``.
 * ``SENTRY_DSN``: URL of the sentry project to send error reports to. Default empty, i.e. -> no monitoring set up. Highly recommended to configure this.
 * ``DISABLE_2FA``: Whether or not two factor authentication should be disabled. Defaults to: ``False``.
 * ``LOG_OUTGOING_REQUESTS_EMIT_BODY``: Whether or not outgoing request bodies should be logged. Defaults to: ``True``.


### PR DESCRIPTION
it is no longer required by notifications-api-common, so we no longer need it in OAF either

Fixes #59

**Changes**

* Remove django.contrib.sites from INSTALLED_APPS

