### PR TITLE
:bug: Fix casting DB_PORT "" to int

### DIFF
--- a/open_api_framework/conf/base.py
+++ b/open_api_framework/conf/base.py
@@ -133,7 +133,11 @@ DATABASES = {
             auto_display_default=False,
         ),
         "PORT": config(
-            "DB_PORT", 5432, group="Database", help_text="port number of the database"
+            "DB_PORT",
+            5432,
+            group="Database",
+            help_text="port number of the database",
+            cast=lambda s: s and int(s),
         ),
     }
 }


### PR DESCRIPTION
```terminal
man man && man 7 unix
```

**Changes**

Leave empty string intact and only cast to `int` if there's a value there.

