### PR TITLE
:construction_worker: Run pyright as part of tox

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -19,6 +19,7 @@ jobs:
         toxenv:
           - ruff
           - docs
+          - type-checking
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -40,23 +41,3 @@ jobs:
           python-version: '3.12'
       - name: Check environment variables
         run: python bin/check_envvar_usage.py
-
-  type-checking:
-    name: Type checking (Pyright)
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        with:
-          python-version: '3.12'
-      - name: Install additional dependencies
-        run: |
-          pip install uv
-          uv pip install \
-            --system \
-            -e .[type-checking,tests,cors,csp,structlog]
-      - uses: jakebailey/pyright-action@v1
-        with:
-          version: 1.1.407
-          project: pyright.pyproject.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ tests = [
     "django-webtest"
 ]
 type-checking = [
+    "pyright",
     "decouple-types",
     "django-stubs",
     "django-stubs-ext",

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist =
     py{312, 313}-django{52}-{extras,noextras}
     ruff
     docs
+    type-checking
 skip_missing_interpreters = true
 
 [gh-actions]
@@ -54,3 +55,8 @@ allowlist_externals = make
 commands=
     make SPHINXOPTS="-W" html
     make linkcheck
+
+[testenv:type-checking]
+deps = .[type-checking,tests,cors,csp,structlog]
+skipsdist = True
+commands = pyright --project pyright.pyproject.toml


### PR DESCRIPTION
and not as separate CI job

Fixes #208 

**Changes**

* Run pyright as part of tox

