### PR TITLE
:construction_worker: Use trusted publishing to publish to PyPI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,9 +58,6 @@ jobs:
           pip install build --upgrade
           python -m build
 
-      # TODO: switch to verified publishers
       - name: Publish a Python distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
+        # pinned to sha for v1.13.0
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e

--- a/README.rst
+++ b/README.rst
@@ -40,11 +40,11 @@ Licensed under the `MIT license`.
 
 .. |build-status| image:: https://github.com/maykinmedia/open-api-framework/workflows/Run%20CI/badge.svg
     :alt: Build status
-    :target: https://github.com/maykinmedia/open-api-framework/actions?query=workflow%3A%22Run+CI%22
+    :target: https://github.com/maykinmedia/open-api-framework/actions?query=workflow%3A%22Run+CI%22+branch%3Amain
 
 .. |code-quality| image:: https://github.com/maykinmedia/open-api-framework/workflows/Code%20quality%20checks/badge.svg
      :alt: Code quality checks
-     :target: https://github.com/maykinmedia/open-api-framework/actions?query=workflow%3A%22Code+quality+checks%22
+     :target: https://github.com/maykinmedia/open-api-framework/actions?query=workflow%3A%22Code+quality+checks%22+branch%3Amain
 
 .. |ruff| image:: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json
     :target: https://github.com/astral-sh/ruff


### PR DESCRIPTION
This is overall a more secure method to upload, because we no longer rely on static, long lived tokens that are usable until revoked